### PR TITLE
fix: downgrade chalk and ora to CommonJS versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   "license": "MIT",
   "dependencies": {
     "@types/semver": "^7.7.0",
-    "chalk": "^5.3.0",
+    "chalk": "^4.1.2",
     "commander": "^11.1.0",
     "fast-glob": "^3.3.2",
     "gray-matter": "^4.0.3",
-    "ora": "^8.0.1",
+    "ora": "^5.4.1",
     "semver": "^7.7.2",
     "zod": "^3.22.4"
   },


### PR DESCRIPTION
- Downgrade chalk from 5.x to 4.x (last CommonJS version)
- Downgrade ora from 8.x to 5.x (last CommonJS version)
- Fixes ESM/CommonJS compatibility issues when running linter

## Motivation

Resolves issue #9 
